### PR TITLE
Add live now filter to results

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,7 +934,11 @@
 </div>
 </div>
 
-<div class="sort-options"><button class="sort-btn active" id="sortByCompatibility" onclick="sortResults('compatibility')">🎯 الأعلى توافقًا</button><button class="sort-btn" id="sortByLocation" onclick="sortResults('location')">📍 الأقرب للموقع</button></div>
+<div class="sort-options">
+    <button class="sort-btn active" id="sortByCompatibility" onclick="sortResults('compatibility')">🎯 الأعلى توافقًا</button>
+    <button class="sort-btn" id="filterLiveNow" onclick="toggleLiveFilter()">🔴 مباشر الآن</button>
+    <button class="sort-btn" id="sortByLocation" onclick="sortResults('location')">📍 الأقرب للموقع</button>
+</div>
 
 <div id="resultsList"></div>
 </div>
@@ -958,6 +962,9 @@
 <script>
         // بيانات المجالس
         let majalisData = [];
+        let originalResults = [];
+        let currentSort = 'compatibility';
+        let showOnlyLive = false;
 
         // متغيرات التفضيلات المحسنة
         let selectedPreferences = {
@@ -1398,36 +1405,19 @@
                 majlis.isLive = isCurrentlyLive(majlis);
             });
 
-            // ترتيب حسب التوافق افتراضيًا
-            results.sort((a, b) => b.compatibility - a.compatibility);
-
-            // تحديث العدادات
-            document.getElementById('resultsCount').textContent = results.length;
+            // حفظ العدادات الأساسية
             document.getElementById('totalCount').textContent = results.length;
             document.getElementById('liveCount').textContent = results.filter(m => m.isLive).length;
             document.getElementById('compatibilityCount').textContent = results.filter(m => m.compatibility >= 80).length;
 
-            // عرض قائمة النتائج
-            const resultsList = document.getElementById('resultsList');
-            resultsList.innerHTML = '';
+            // حفظ النتائج الأصلية وإعادة تعيين خيارات العرض
+            originalResults = results.slice();
+            currentSort = 'compatibility';
+            showOnlyLive = false;
+            const liveBtn = document.getElementById('filterLiveNow');
+            if (liveBtn) liveBtn.classList.remove('active');
 
-            if (results.length === 0) {
-                resultsList.innerHTML = `
-                    <div style="text-align: center; padding: 40px; color: rgba(255,255,255,0.7);">
-                        <div style="font-size: 48px; margin-bottom: 20px;">😔</div>
-                        <h3>لا توجد مجالس تطابق تفضيلاتك</h3>
-                        <p>جرب تعديل الفلاتر أو توسيع نطاق البحث</p>
-                    </div>
-                `;
-            } else {
-                results.forEach(majlis => {
-                    const card = createMajlisCard(majlis);
-                    resultsList.appendChild(card);
-                });
-            }
-
-            // حفظ النتائج للترتيب
-            window.currentResults = results;
+            applyFiltersAndSort();
         }
 
         // إنشاء بطاقة مجلس محسنة
@@ -1511,37 +1501,79 @@
 
                     // ترتيب النتائج المحسن
         function sortResults(type) {
-            if (!window.currentResults) return;
-            
+            if (!originalResults.length) return;
+
+            currentSort = type;
+
             const compatibilityBtn = document.getElementById('sortByCompatibility');
             const locationBtn = document.getElementById('sortByLocation');
-            
+
             if (type === 'compatibility') {
-                window.currentResults.sort((a, b) => b.compatibility - a.compatibility);
                 compatibilityBtn.classList.add('active');
                 locationBtn.classList.remove('active');
             } else if (type === 'location') {
-                if (selectedPreferences.userLocation) {
-                    // ترتيب حسب المسافة (محاكاة بسيطة)
-                    window.currentResults.sort((a, b) => {
-                        // هنا يمكن إضافة حساب المسافة الفعلية باستخدام coordinates
-                        return Math.random() - 0.5; // ترتيب عشوائي للمحاكاة
-                    });
-                } else {
+                if (!selectedPreferences.userLocation) {
                     showNotification('الرجاء تحديد موقعك أولاً', 'error');
                     return;
                 }
                 locationBtn.classList.add('active');
                 compatibilityBtn.classList.remove('active');
             }
-            
-            // إعادة عرض النتائج
+
+            applyFiltersAndSort();
+        }
+
+        function toggleLiveFilter() {
+            showOnlyLive = !showOnlyLive;
+            const liveBtn = document.getElementById('filterLiveNow');
+            if (showOnlyLive) {
+                liveBtn.classList.add('active');
+            } else {
+                liveBtn.classList.remove('active');
+            }
+            applyFiltersAndSort();
+        }
+
+        function applyFiltersAndSort() {
+            let results = originalResults.slice();
+
+            if (showOnlyLive) {
+                results = results.filter(m => m.isLive);
+            }
+
+            if (currentSort === 'location') {
+                if (selectedPreferences.userLocation) {
+                    results.sort(() => Math.random() - 0.5);
+                } else {
+                    currentSort = 'compatibility';
+                    document.getElementById('sortByLocation').classList.remove('active');
+                    document.getElementById('sortByCompatibility').classList.add('active');
+                }
+            } else {
+                results.sort((a, b) => b.compatibility - a.compatibility);
+            }
+
+            window.currentResults = results;
+
+            document.getElementById('resultsCount').textContent = results.length;
+
             const resultsList = document.getElementById('resultsList');
             resultsList.innerHTML = '';
-            window.currentResults.forEach(majlis => {
-                const card = createMajlisCard(majlis);
-                resultsList.appendChild(card);
-            });
+
+            if (results.length === 0) {
+                resultsList.innerHTML = `
+                    <div style="text-align: center; padding: 40px; color: rgba(255,255,255,0.7);">
+                        <div style="font-size: 48px; margin-bottom: 20px;">😔</div>
+                        <h3>لا توجد مجالس تطابق تفضيلاتك</h3>
+                        <p>جرب تعديل الفلاتر أو توسيع نطاق البحث</p>
+                    </div>
+                `;
+            } else {
+                results.forEach(majlis => {
+                    const card = createMajlisCard(majlis);
+                    resultsList.appendChild(card);
+                });
+            }
         }
 
         // فتح الموقع الجغرافي


### PR DESCRIPTION
## Summary
- add "مباشر الآن" filter button on results page
- store original results and new sort state
- implement functions to filter live councils and combine with sorting

## Testing
- `php -l get_majalis.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3e943e4832eba2b5e64a7977dc1